### PR TITLE
Remove bias in augmented loss + fix perplexity

### DIFF
--- a/model/lang_model_sgd.py
+++ b/model/lang_model_sgd.py
@@ -1,6 +1,3 @@
-import copy
-import numpy as np
-import tensorflow as tf
 from keras import backend as K
 from keras.optimizers import Optimizer
 from keras.callbacks import LearningRateScheduler

--- a/model/utils.py
+++ b/model/utils.py
@@ -1,0 +1,76 @@
+import numpy as np
+from keras import backend as K
+from keras.engine import InputSpec
+from keras.engine import Layer
+from keras import constraints
+from keras import initializers
+from keras import regularizers
+from keras.callbacks import Callback
+
+
+class Bias(Layer):
+    def __init__(self, bias_initializer='zeros',
+                 bias_regularizer=None,
+                 bias_constraint=None,
+                 **kwargs):
+        if 'input_shape' not in kwargs and 'input_dim' in kwargs:
+            kwargs['input_shape'] = (kwargs.pop('input_dim'),)
+        super(Bias, self).__init__(**kwargs)
+        self.bias_initializer = initializers.get(bias_initializer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.bias_constraint = constraints.get(bias_constraint)
+        self.input_spec = InputSpec(min_ndim=2)
+        self.supports_masking = True
+
+    def build(self, input_shape):
+        assert len(input_shape) >= 2
+        input_dim = input_shape[-1]
+
+        self.bias = self.add_weight(shape=(input_dim,),
+                                    initializer=self.bias_initializer,
+                                    name='bias',
+                                    regularizer=self.bias_regularizer,
+                                    constraint=self.bias_constraint)
+        
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        return K.bias_add(inputs, self.bias)
+
+    def compute_output_shape(self, input_shape):
+        assert input_shape and len(input_shape) >= 2
+        assert input_shape[-1]
+        output_shape = list(input_shape)
+        return tuple(output_shape)
+
+    def get_config(self):
+        config = {
+            'bias_initializer': initializers.serialize(self.bias_initializer),
+            'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+            'bias_constraint': constraints.serialize(self.bias_constraint)
+        }
+        base_config = super(Bias, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+
+def log_perplexity(y_true, y_pred):
+    cross_entropy = K.mean(K.categorical_crossentropy(y_true, y_pred), axis=-1)
+    return cross_entropy
+
+
+def perplexity(y_true, y_pred):
+    # will be calculated by perplexity logger
+    return K.mean(K.zeros_like(y_pred), axis=-1)
+
+
+class PerplexityLogger(Callback):
+    def on_batch_end(self, batch, logs=None):
+        logs = logs or {}
+        logs['perplexity'] = np.exp(logs['log_perplexity'])
+
+    def on_epoch_end(self, epoch, logs=None):
+        if logs is not None:
+            logs['perplexity'] = np.exp(logs['log_perplexity'])
+            logs['val_perplexity'] = np.exp(logs['val_log_perplexity'])

--- a/train.py
+++ b/train.py
@@ -51,7 +51,7 @@ def train_augmented(network_size, dataset_kind, tying=False, epochs=40, stride=0
     train_steps, train_generator = dp.make_batch_iter(dataset, sequence_size=sequence_size, stride=stride)
     valid_steps, valid_generator = dp.make_batch_iter(dataset, kind="valid", sequence_size=sequence_size, stride=stride)
 
-    # make one hot model
+    # make augmented model
     model = AugmentedModel(vocab_size, sequence_size, setting, tying=tying, checkpoint_path=LOG_ROOT)
     model.compile()
     model.fit_generator(train_generator, train_steps, valid_generator, valid_steps, epochs=epochs)


### PR DESCRIPTION
* removing bias in augmented loss calculation (needed to add a Bias layer for the weight tying model)
* now the last layer of the augmented model is a softmax. We use the log to recover pre-activation
* fix categorical crossentropy calculation for perplexity and augmented loss, it was the opposite ordering
* fixing running average perplexity calculation by using a hacky callback which exponentiated a running average of the cross-entropy. This replicate this implementation [here](https://github.com/tensorflow/models/blob/3d792f935d652b2c7793b95aa3351a5551dc2401/tutorials/rnn/ptb/ptb_word_lm.py#L319) (however because of the convexity this will only make its value bigger)
* removing explicit tensorflow dependency 

Everything is running well but I couldn't check the performance for more than 2 epochs since I don't have a GPU so that training is very slow...